### PR TITLE
Use correct event for write stream

### DIFF
--- a/src/get-survey-results.js
+++ b/src/get-survey-results.js
@@ -51,7 +51,7 @@ async function writeFile(token, url, destinationStream) {
   const readStream = await zipFile.openReadStream(entry);
   readStream.pipe(destinationStream);
   return new Promise(resolve => {
-    destinationStream.on("end", () => {
+    destinationStream.on("finish", () => {
       resolve();
     });
   });


### PR DESCRIPTION
finished is better than end as it waits for the file to be completely
written to disk.