### PR TITLE
chore: bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2279,9 +2279,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.0.tgz",
-      "integrity": "sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
       "dev": true,
       "requires": {
         "component-emitter": "~1.3.0",
@@ -2293,7 +2293,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -6550,9 +6550,9 @@
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz",
+      "integrity": "sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==",
       "dev": true
     },
     "xtend": {


### PR DESCRIPTION
This bumps dependencies to quell warnings about xmlhttprequest-ssl from
the GitHub interface and from `npm audit`.