### PR TITLE
Extend the timeout to 600 seconds

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -33,7 +33,7 @@ custom:
 
 functions:
   storeSurveys:
-    timeout: 300
+    timeout: 600
     handler: handler.storeSurveys
     events:
       - schedule: rate(30 minutes)


### PR DESCRIPTION
This should give more time for all the surveys to be processed.