### PR TITLE
chore: update Node.js 12.x to 14.x

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: som-qualtrics-survey-responses
 variablesResolutionMode: 20210326
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   stage: dev
   region: us-west-2
   memorySize: 256


### PR DESCRIPTION
Node.js 12.x will be unsupported in another 6 weeks or so. Switch to
14.x which is supported for another year.