### PR TITLE
Prevent concurrent attempts to deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
 
+concurrency: deploy-dev
+
 jobs:
   test:
     name: Run Tests

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - '*'
 
+concurrency: deploy-production
+
 jobs:
   test:
     name: Run Tests


### PR DESCRIPTION
When we merge a few things to master at the same time each will be deployed which causes and error with stack formation in AWS. By adding concurrency groups we can ensure that each job is completed before another starts

Because CloudFormation runs async from our job we can't just cancel the current job when a new one starts, we have to finish each task before starting the next.